### PR TITLE
Update docs for 1.2.1 release of distant-web and distant-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 - This project adheres to [Semantic Versioning](http://semver.org/).
 - This change log follows [keepachangelog.com](http://keepachangelog.com/) recommendations.
 
+## 1.2.1 - 2023-10-03
+### Fixed
+- `distant-web`
+  - Fixing use of `import` vs `require` `KAJ-1926`
+- `distant-controller`
+  - Fixing vchannel access `KAJ-1926`
+
 ## 1.2.0 - 2023-09-13
 ### Added
 - `distant-remote`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 
 ## 1.2.1 - 2023-10-03
 ### Fixed
-- `distant-web`
-  - Fixing use of `import` vs `require` `KAJ-1926`
-- `distant-controller`
-  - Fixing vchannel access `KAJ-1926`
+- `distant-web`'s use of `import` vs `require`. `KAJ-1926`
+- `distant-controller` - Add resilience to vchannel import. `KAJ-1926`
 
 ## 1.2.0 - 2023-09-13
 ### Added


### PR DESCRIPTION
Updating the changelog for the 1.2.1 release. Avoiding mentioning use of browser.